### PR TITLE
Allow custom menu key and drop Fabric API by using malilib's handlers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:0.9.1+build.205"
 
     //Fabric api
-    modImplementation "net.fabricmc.fabric-api:fabric-api:0.23.1+1.15"
+    //modImplementation "net.fabricmc.fabric-api:fabric-api:0.23.1+1.15"
 
     modCompile "fi.dy.masa.malilib:malilib-fabric-1.15.2:0.10.0-dev.21+arne.1"
 }

--- a/src/main/java/github/io/lucunji/explayerenderer/KeyBindHandler.java
+++ b/src/main/java/github/io/lucunji/explayerenderer/KeyBindHandler.java
@@ -1,18 +1,20 @@
 package github.io.lucunji.explayerenderer;
 
+import fi.dy.masa.malilib.hotkeys.IHotkeyCallback;
+import fi.dy.masa.malilib.hotkeys.IKeybind;
+import fi.dy.masa.malilib.hotkeys.KeyAction;
 import github.io.lucunji.explayerenderer.client.render.screen.GuiConfig;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.fabricmc.fabric.api.event.client.ClientTickCallback;
 import net.minecraft.client.MinecraftClient;
 
-public class KeyBindHandler implements ClientTickEvents.StartTick {
+public class KeyBindHandler implements IHotkeyCallback {
 
     @Override
-    public void onStartTick(MinecraftClient client) {
-        if (client.skipGameRender || MinecraftClient.getInstance().world == null) return;
-
-        if (Main.MASTER_CONTROL.wasPressed() && client.currentScreen == null) {
+    public boolean onKeyAction(KeyAction action, IKeybind key) {
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (client.currentScreen instanceof GuiConfig)
+            client.currentScreen.onClose();
+        else
             client.openScreen(new GuiConfig());
-        }
+        return true;
     }
 }

--- a/src/main/java/github/io/lucunji/explayerenderer/KeybindProvider.java
+++ b/src/main/java/github/io/lucunji/explayerenderer/KeybindProvider.java
@@ -1,0 +1,17 @@
+package github.io.lucunji.explayerenderer;
+
+import fi.dy.masa.malilib.hotkeys.IKeybindManager;
+import fi.dy.masa.malilib.hotkeys.IKeybindProvider;
+import github.io.lucunji.explayerenderer.config.Configs;
+
+public class KeybindProvider implements IKeybindProvider {
+    @Override
+    public void addKeysToMap(IKeybindManager manager) {
+        manager.addKeybindToMap(Configs.MENU_OPEN_KEY.getKeybind());
+    }
+
+    @Override
+    public void addHotkeys(IKeybindManager manager) {
+        // Not necessary
+    }
+}

--- a/src/main/java/github/io/lucunji/explayerenderer/Main.java
+++ b/src/main/java/github/io/lucunji/explayerenderer/Main.java
@@ -1,29 +1,21 @@
 package github.io.lucunji.explayerenderer;
 
 import fi.dy.masa.malilib.config.ConfigManager;
+import fi.dy.masa.malilib.event.InputEventHandler;
 import github.io.lucunji.explayerenderer.config.ConfigHandler;
 import github.io.lucunji.explayerenderer.config.Configs;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.fabricmc.fabric.impl.client.keybinding.KeyBindingRegistryImpl;
-import net.minecraft.client.options.KeyBinding;
-import net.minecraft.client.util.InputUtil;
 
 public class Main implements ModInitializer{
 
     public static final String MOD_ID = "explayerenderer";
-
-    public static final KeyBinding MASTER_CONTROL = new KeyBinding("key." + MOD_ID + ".master_control",
-            InputUtil.Type.KEYSYM,
-            InputUtil.fromName("key.keyboard.f8").getKeyCode(),
-            "key.categories.ui");
 
     @Override
     public void onInitialize(){
         ConfigManager.getInstance().registerConfigHandler(MOD_ID, new ConfigHandler());
         new Configs();
         ConfigHandler.loadFile();
-        KeyBindingRegistryImpl.registerKeyBinding(MASTER_CONTROL);
-        ClientTickEvents.START_CLIENT_TICK.register(new KeyBindHandler());
+        InputEventHandler.getKeybindManager().registerKeybindProvider(new KeybindProvider());
+        Configs.MENU_OPEN_KEY.getKeybind().setCallback(new KeyBindHandler());
     }
 }

--- a/src/main/java/github/io/lucunji/explayerenderer/client/render/screen/GuiConfig.java
+++ b/src/main/java/github/io/lucunji/explayerenderer/client/render/screen/GuiConfig.java
@@ -61,9 +61,6 @@ public class GuiConfig extends GuiConfigsBase {
     @Override
     public boolean onKeyTyped(int keyCode, int scanCode, int modifiers) {
         if (super.onKeyTyped(keyCode, scanCode, modifiers)) return true;
-        if (Main.MASTER_CONTROL.matchesKey(keyCode, scanCode)) {
-            this.onClose();
-        }
         return true;
     }
 

--- a/src/main/java/github/io/lucunji/explayerenderer/config/Configs.java
+++ b/src/main/java/github/io/lucunji/explayerenderer/config/Configs.java
@@ -4,12 +4,14 @@ import com.google.common.collect.ImmutableList;
 import fi.dy.masa.malilib.config.IConfigBase;
 import fi.dy.masa.malilib.config.options.ConfigBoolean;
 import fi.dy.masa.malilib.config.options.ConfigDouble;
+import fi.dy.masa.malilib.config.options.ConfigHotkey;
 import fi.dy.masa.malilib.config.options.ConfigString;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class Configs {
+    public static final ConfigHotkey MENU_OPEN_KEY;
     public static final ConfigBoolean SPECTATOR_AUTO_SWITCH;
     public static final ConfigString PLAYER_NAME;
 
@@ -36,6 +38,7 @@ public class Configs {
     public static final ConfigBoolean USE_WORLD_LIGHT;
 
     static {
+        MENU_OPEN_KEY = Category.PARAMETERS.add(new ConfigHotkey("openMenuKey", "F8", "explayerenderer.gui.settings.open_key"));
         SPECTATOR_AUTO_SWITCH = Category.PARAMETERS.add(new ConfigBoolean("spectatorAutoSwitch", true, "explayerenderer.gui.settings.spectator_auto_switch.desc"));
         PLAYER_NAME = Category.PARAMETERS.add(new ConfigString("playerName", "", "explayerenderer.gui.settings.player_name.desc"));
 

--- a/src/main/resources/assets/explayerenderer/lang/en_us.json
+++ b/src/main/resources/assets/explayerenderer/lang/en_us.json
@@ -2,6 +2,7 @@
   "key.explayerenderer.master_control": "Extra Player Renderer",
   "explayerenderer.gui.settings": "Extra Player Renderer Settings",
   "explayerenderer.gui.settings.parameters": "Parameters",
+  "explayerenderer.gui.settings.open_key": "Key to open config menu",
   "explayerenderer.gui.settings.spectator_auto_switch.desc": "Automatically switch player model in spectator mode.\nOverrides playerName option if enabled.",
   "explayerenderer.gui.settings.player_name.desc": "The name of player to render. It will be your name in default.",
   "explayerenderer.gui.settings.offset_x.desc": "X offset of rendered model.",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,6 @@
   ],
 
   "depends": {
-    "fabric": ">=0.23.0",
     "malilib": "*",
     "fabricloader": ">=0.9.0",
     "minecraft": "1.15.x"


### PR DESCRIPTION
Changes the way the keybind is handled to be in malilib, so the mod no longer needs Fabric API. The keybind is also added to the config so it can be changed.

The empty `addHotkeys` method isn't necessary, that is just to add the hotkeys to the global malilib menu, and it's just a pain.

Needs translation to `zh_cn.json`, since I don't know the language.

Should work the same in newer versions.